### PR TITLE
Allow customisation of foldenable default

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,14 @@ let g:fold_rspec_default_level = 2
 
 See `:h 'foldlevel'` for more.
 
+To disable folding by default for Rspec files, add a line like the one below to your `vimrc`:
+
+```viml
+let g:fold_rspec_default_enable = 0
+```
+
+See `:h 'foldenable'` for more.
+
 License
 -------
 

--- a/ftplugin/ruby.vim
+++ b/ftplugin/ruby.vim
@@ -1,5 +1,9 @@
 if expand('%:t:r') =~ '_spec$'
-  let &l:foldenable = 1
+  if exists('g:fold_rspec_default_enable')
+    let &l:foldenable = g:fold_rspec_default_enable
+  else
+    let &l:foldenable = 1
+  endif
   if exists('g:fold_rspec_default_level')
     let &l:foldlevel  = g:fold_rspec_default_level
   endif


### PR DESCRIPTION
Hi,

Thanks very much for vim-fold-rspec, works great, and seems very fast, nice work :-)

One thing that threw me though was the enabling folding by default for RSpec files, despite me having `set nofoldenable` in my `.vimrc`. I understand this is likely to be very much desired behaviour for some people, but I'd prefer to only enable folding when I need it, so I've updated the plugin to allow the default behaviour to be customised by setting a global variable, following the existing naming convention.

Hope this is helpful, but no worries if not. 

Mark